### PR TITLE
Fixed a non-fatal error when fetching the "devtools" package

### DIFF
--- a/repro.in
+++ b/repro.in
@@ -353,7 +353,7 @@ function cmd_check(){
       DEVTOOLS_PKG="$ARCHIVEURL/d/devtools/${DEVTOOLS}.pkg.tar.zst"
     elif [[ "${BUILDTOOL}" = devtools ]] ; then
       DEVTOOLS="${BUILDTOOL}-${BUILDTOOLVER}"
-      DEVTOOLS_PKG="$ARCHIVEURL/${BUILDTOOL:0:1}/${DEVTOOLS}.pkg.tar${pkg##*tar}"
+      DEVTOOLS_PKG="$ARCHIVEURL/${BUILDTOOL:0:1}/${BUILDTOOL}/${DEVTOOLS}.pkg.tar${pkg##*tar}"
     fi
     msg2 "Using devtools version: %s" "${DEVTOOLS}"
 


### PR DESCRIPTION
Fixed a non-fatal error when fetching the "[devtools](https://archlinux.org/packages/extra/any/devtools)" package, below is a log excerpt:
```
Installing devtools from https://archive.archlinux.org/packages/d/devtools-1:1.4.0-3-any.pkg.tar.zst
:: Retrieving packages...
 devtools-1:1.4.0-3-any.pkg.tar.zst failed to download
error: failed retrieving file 'devtools-1:1.4.0-3-any.pkg.tar.zst' from archive.archlinux.org : The requested URL returned error: 404
warning: failed to retrieve some files
```

Fixes: #3