### PR TITLE
Implemented the ability to specify a custom "pacman" configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,10 @@ Work in progress. Please read the code before using.
 
 Patches very welcome.
 
-- Support fetching build dependencies from a custom pacman repository
 - Possibly also support fetching build dependencies from a custom archive, and
   only if the package is not present there, try archive.archlinux.org
 
-Both of them need to be implemented in `aur-buildinfo` (which may need to read
+This would need to be implemented in `aur-buildinfo` (which may need to read
 a configuration file in the future).
 
 ## Considerations

--- a/docs/aur-repro.8.txt
+++ b/docs/aur-repro.8.txt
@@ -44,6 +44,12 @@ Options
         Set the output directory for the rebuilt packages. Defaults to
         `./build`.
 
+ *-c*::
+        Specify a custom pacman configuration file, see: /usr/local/share/doc/aur-repro/pacman.conf.example
+
+ *-k*::
+        Specify a list of additional pacman keys to be fetched automatically, see: /usr/local/share/doc/aur-repro/key.list.example
+
 See Also
 --------
-linkman:makepkg[8] linkman:aur-repro.conf[5]
+linkman:makepkg[8] linkman:aur-repro.conf[5] linkman:pacman.conf[5] linkman:key.list[5]

--- a/examples/key.list.example
+++ b/examples/key.list.example
@@ -1,0 +1,11 @@
+# Below you can specify any additional "pacman" signing keys you may need
+# to be fetched automatically via the keyserver "pacman" uses by default
+# using this key list file and the "-k" argument:
+#
+# You can also specify any additional "pacman" repositories you may need to
+# resolve dependencies that are not in the official "Arch Linux" repositories
+# using the "-c" argument and a "pacman" configuration file, see:
+# /usr/local/share/doc/aur-repro/pacman.conf.example
+#
+#13578D45682166C2DC036926FBA462E35DE14986
+#13578D45682166C2DC036926FBA462E35DE14986

--- a/examples/pacman.conf.example
+++ b/examples/pacman.conf.example
@@ -1,0 +1,115 @@
+#
+# /etc/pacman.conf
+#
+# See the pacman.conf(5) manpage for option and repository directives
+
+#
+# GENERAL OPTIONS
+#
+[options]
+# The following paths are commented out with their default values listed.
+# If you wish to use different paths, uncomment and update the paths.
+#RootDir     = /
+#DBPath      = /var/lib/pacman/
+#CacheDir    = /var/cache/pacman/pkg/
+#LogFile     = /var/log/pacman.log
+#GPGDir      = /etc/pacman.d/gnupg/
+#HookDir     = /etc/pacman.d/hooks/
+HoldPkg     = pacman glibc
+#XferCommand = /usr/bin/curl -L -C - -f -o %o %u
+#XferCommand = /usr/bin/wget --passive-ftp -c -O %o %u
+#CleanMethod = KeepInstalled
+Architecture = auto
+
+# Pacman won't upgrade packages listed in IgnorePkg and members of IgnoreGroup
+#IgnorePkg   =
+#IgnoreGroup =
+
+#NoUpgrade   =
+#NoExtract   =
+
+# Misc options
+#UseSyslog
+#Color
+#NoProgressBar
+CheckSpace
+#VerbosePkgLists
+ParallelDownloads = 5
+DownloadUser = alpm
+#DisableSandbox
+
+# By default, pacman accepts packages signed by keys that its local keyring
+# trusts (see pacman-key and its man page), as well as unsigned packages.
+SigLevel    = Required DatabaseOptional
+LocalFileSigLevel = Optional
+#RemoteFileSigLevel = Required
+
+# NOTE: You must run `pacman-key --init` before first using pacman; the local
+# keyring can then be populated with the keys of all official Arch Linux
+# packagers with `pacman-key --populate archlinux`.
+
+#
+# REPOSITORIES
+#   - can be defined here or included from another file
+#   - pacman will search repositories in the order defined here
+#   - local/custom mirrors can be added here or in separate files
+#   - repositories listed first will take precedence when packages
+#     have identical names, regardless of version number
+#   - URLs will have $repo replaced by the name of the current repo
+#   - URLs will have $arch replaced by the name of the architecture
+#
+# Repository entries are of the format:
+#       [repo-name]
+#       Server = ServerName
+#       Include = IncludePath
+#
+# The header [repo-name] is crucial - it must be present and
+# uncommented to enable the repo.
+#
+
+# The testing repositories are disabled by default. To enable, uncomment the
+# repo name header and Include lines. You can add preferred servers immediately
+# after the header, and they will be used before the default mirrors.
+
+#[core-testing]
+#Include = /etc/pacman.d/mirrorlist
+
+[core]
+Include = /etc/pacman.d/mirrorlist
+
+#[extra-testing]
+#Include = /etc/pacman.d/mirrorlist
+
+[extra]
+Include = /etc/pacman.d/mirrorlist
+
+# If you want to run 32 bit applications on your x86_64 system,
+# enable the multilib repositories as required here.
+
+#[multilib-testing]
+#Include = /etc/pacman.d/mirrorlist
+
+#[multilib]
+#Include = /etc/pacman.d/mirrorlist
+
+# An example of a custom package repository.  See the pacman manpage for
+# tips on creating your own repositories.
+#[custom]
+#SigLevel = Optional TrustAll
+#Server = file:///home/custompkgs
+
+# Below you can specify additional "pacman" repositories you may need below
+# then pass this configuration file to this tool using the "-c" argument
+# to allow it to resolve dependencies that are not in the
+# official "Arch Linux" repositories.
+#
+# Please note only HTTP(S) locations are supported.
+#
+# You can also configure any additional "pacman" signing keys you may need
+# to be fetched automatically via the keyserver "pacman" uses by default
+# using the "-k" argument and a key list file, see:
+# /usr/local/share/doc/aur-repro/key.list.example
+#
+#[staging]
+#SigLevel = Required
+#Server = http://localhost/aurutils/$repo/$arch

--- a/examples/repro.conf.example
+++ b/examples/repro.conf.example
@@ -9,3 +9,7 @@ DIFFOSCOPE="diffoscope"
 HOSTMIRROR="http://mirror.neuf.no/archlinux/\$repo/os/\$arch"
 
 IMGDIRECTORY="/tmp/arch_img"
+
+PACMANCONFIG=""
+
+KEYLIST=""

--- a/repro.in
+++ b/repro.in
@@ -26,6 +26,10 @@ ARCHIVEURL="${ARCH_ARCHIVE_CACHE:-https://archive.archlinux.org/packages}"
 IMGDIRECTORY=$(mktemp -dt XXXXXXXXXX.arch_img)
 trap "{ rm -r $IMGDIRECTORY; }" EXIT
 
+PACMANCONFIG=""
+
+KEYLIST=""
+
 DIFFOSCOPE="diffoscope"
 
 # Turn on/off check in repro
@@ -550,6 +554,20 @@ __END__
     printf 'LANG=en_US.UTF-8\n' > "$build_root_dir/etc/locale.conf"
     exec_nspawn "$build" locale-gen
 
+    exec_nspawn "$build" pacman-key --init
+    exec_nspawn "$build" pacman-key --populate archlinux
+    if [[ -f "$KEYLIST" ]]; then
+        while read -r fingerprint; do
+            # Skip empty lines or comments
+            [[ -z "$fingerprint" || "$fingerprint" =~ ^# ]] && continue
+
+            exec_nspawn "$build" pacman-key --recv-keys "$fingerprint"
+            exec_nspawn "$build" pacman-key --lsign-key "$fingerprint"
+        done < "$KEYLIST"
+    fi
+    [[ -f "$PACMANCONFIG" ]] && cp "$PACMANCONFIG" "$build_root_dir/etc/pacman.conf"
+    exec_nspawn "$build" pacman -Sy --noconfirm
+
     printf 'builduser ALL = NOPASSWD: /usr/bin/pacman\n' > "$build_root_dir/etc/sudoers.d/builduser-pacman"
     exec_nspawn "$build" useradd -m -s /bin/bash -d /build builduser
     echo "keyserver-options auto-key-retrieve" | install -Dm644 /dev/stdin "$build_root_dir/build/.gnupg/gpg.conf"
@@ -586,6 +604,8 @@ General Options:
  -n                           Run makepkg with --nocheck
  -V                           Print version information
  -o <path>                    Set the output directory (default: ./build)
+ -c                           Specify a custom pacman configuration file, see: /usr/local/share/doc/aur-repro/pacman.conf.example
+ -k                           Specify a list of additional pacman keys to be fetched automatically, see: /usr/local/share/doc/aur-repro/key.list.example
 __END__
 }
 
@@ -594,7 +614,7 @@ function print_version() {
 }
 
 function parse_args() {
-    while getopts :hdnfVo: arg; do
+    while getopts :hdnfVo:c:k: arg; do
         case $arg in
             h) print_help; exit 0;;
             V) print_version; exit 0;;
@@ -602,6 +622,8 @@ function parse_args() {
             d) run_diffoscope=1;;
             n) NOCHECK=1;;
             o) OUTDIR="$OPTARG";;
+            c) PACMANCONFIG="$OPTARG";;
+            k) KEYLIST="$OPTARG";;
             *) error "unknown argument ${OPTARG}" ; print_help; exit 1;;
         esac
     done


### PR DESCRIPTION
Implemented the ability to specify a custom "[pacman](https://archlinux.org/packages/core/x86_64/pacman)" configuration as well as a list of additional "[pacman](https://archlinux.org/packages/core/x86_64/pacman)" signing keys to be fetched automatically via the key server "[pacman](https://archlinux.org/packages/core/x86_64/pacman)" uses by default, so this tool can resolve dependencies not in the official "[Arch Linux](https://archlinux.org)" repositories.

Usage:
- Setup a local repository to serve pre-built binaries of the dependencies that are not available in the official "[Arch Linux](https://archlinux.org)"  repositories.
- Build the dependencies and add them to the local repository, for this I like to use the "[aurutils](https://aur.archlinux.org/packages/aurutils)" package.
- Create a customized "[pacman](https://archlinux.org/packages/core/x86_64/pacman)" configuration based off "[/usr/local/share/doc/aur-repro/pacman.conf.example](https://github.com/Contribuac/aur-repro-fork/blob/custom-pacman-configuration/examples/pacman.conf.example)" that includes your local repository, please note only HTTP(S) locations are supported so you will need to serve it via a web server, I like to use the lightweight web server built into the "[python](https://archlinux.org/packages/core/x86_64/python)" package.
- If needed create a key list file based off "[/usr/local/share/doc/aur-repro/key.list.example](https://github.com/Contribuac/aur-repro-fork/blob/custom-pacman-configuration/examples/key.list.example)" that specifies any additional "[pacman](https://archlinux.org/packages/core/x86_64/pacman)" signing keys you may need to be fetched automatically via the keyserver "[pacman](https://archlinux.org/packages/core/x86_64/pacman)" uses by default.
- Run "[aur-repro](https://aur.archlinux.org/packages/aur-repro)" with the new "-c" and "-k" arguments specifying your custom "[pacman](https://archlinux.org/packages/core/x86_64/pacman)" configuration and optional key list respectively, a example of this is below:
```
$ aur-repro -c pacman.conf -k key.list planify-4.15.2-1-x86_64.pkg.tar.zst
```
- Profit! 🥳

Fixes: #7